### PR TITLE
feat: 프로덕트카드 썸네일 링크에 tabindex="-1" 적용

### DIFF
--- a/src/components/product-card.html
+++ b/src/components/product-card.html
@@ -1,45 +1,65 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>product-card</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
-  <link rel="stylesheet" href="/src/sass/main.scss" />
-</head>
-<body>
-  <ul class="product-card-list">
-    <li class="product-card">
-      <a href="#" aria-label="상품링크" class="product-card-link">
-        <b class="product-card-title">
-          고랭지 부사 사과 1.3kg (4~5입)
-        </b>
-        <p class="product-card-early-delivery">샛별배송</p>
-        <p class="product-card-description">
-          달콤하게 만나는 부사
-        </p>
-        <div class="product-card-info-price">
-          <span class="product-cart-sale">24%</span>
-          <span class="product-cart-price">24,500 원</span>
-        </div>
-        <div class="product-card-cost">32,500 원</div>
-        <div class="product-card-badges">
-          <span class="product-card-badge badges-primary">Karly Only</span>
-          <span class="product-card-badge badges-info">한정수량</span>
-          <span class="product-card-badge badges-info">희소가치 프로젝트</span>
-        </div>
-      </a>
-
-      <div class="product-card-thumb">
-        <button type="button" aria-label="장바구니 담기" class="product-card-button-icon-cart">
-          <img src="/src/assets/icon-cart.png" alt="장바구니 담기" class="product-card-icon-cart" />
-        </button>
-        <a href="#" aria-label="상품링크">
-          <img src="/src/assets/product01.png" alt="고랭지 부사 사과 1.3kg (4~5입) 썸네일"  class="product-card-thumb-img" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>product-card</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
+    />
+    <link rel="stylesheet" href="/src/sass/main.scss" />
+  </head>
+  <body>
+    <ul class="product-card-list">
+      <li class="product-card">
+        <a
+          href="/src/components/detail.html"
+          aria-label="상품링크"
+          class="product-card-link"
+        >
+          <b class="product-card-title"> 고랭지 부사 사과 1.3kg (4~5입) </b>
+          <p class="product-card-early-delivery">샛별배송</p>
+          <p class="product-card-description">달콤하게 만나는 부사</p>
+          <div class="product-card-info-price">
+            <span class="product-cart-sale">24%</span>
+            <span class="product-cart-price">24,500 원</span>
+          </div>
+          <div class="product-card-cost">32,500 원</div>
+          <div class="product-card-badges">
+            <span class="product-card-badge badges-primary">Karly Only</span>
+            <span class="product-card-badge badges-info">한정수량</span>
+            <span class="product-card-badge badges-info"
+              >희소가치 프로젝트</span
+            >
+          </div>
         </a>
-      </div>
 
-    </li>
-  </ul>
-</body>
+        <div class="product-card-thumb">
+          <button
+            type="button"
+            aria-label="장바구니 담기"
+            class="product-card-button-icon-cart"
+          >
+            <img
+              src="/src/assets/icon-cart.png"
+              alt="장바구니 담기"
+              class="product-card-icon-cart"
+            />
+          </button>
+          <a
+            href="/src/components/detail.html"
+            tabindex="-1"
+            aria-hidden="true"
+          >
+            <img
+              src="/src/assets/product01.png"
+              alt="고랭지 부사 사과 1.3kg (4~5입) 썸네일"
+              class="product-card-thumb-img"
+            />
+          </a>
+        </div>
+      </li>
+    </ul>
+  </body>
 </html>


### PR DESCRIPTION
## PR 유형
- [x] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
tab 키를 이용해서 사이트를 사용하는 사용자를 위해 프로덕트 카드의 tab키 이동 순서를
`상품정보(제목 등 가격) > 장바구니 담기 버튼 > 썸네일` 로 이동하던 것을
`상품정보(제목 등 가격) > 장바구니 담기 버튼` 으로 이동하도록 수정하였습니다.

## 이슈
resolves #91 